### PR TITLE
Optimize documentation for new TYPO3 rendering toolchain

### DIFF
--- a/Documentation/ChangeLog/Index.rst
+++ b/Documentation/ChangeLog/Index.rst
@@ -124,7 +124,7 @@ Version 2.0.0
 Version 1.1.5
 =============
 
-*   Use :php:`->fetch()` instead of :php:`->fetchAssociative()` for TYPO3 v10
+*   Use `->fetch()` instead of `->fetchAssociative()` for TYPO3 v10
     standalone compatibility
 
 Version 1.1.4

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,34 +1,4 @@
 ﻿..  More information about this file:
     https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html#includes-rst-txt
 
-..  ----------
-..  text roles
-..  ----------
-
-..  role:: aspect(emphasis)
-..  role:: bash(code)
-..  role:: html(code)
-..  role:: js(code)
-..  role:: php(code)
-..  role:: rst(code)
-..  role:: sep(strong)
-..  role:: sql(code)
-
-..  role:: tsconfig(code)
-    :class: typoscript
-
-..  role:: typoscript(code)
-..  role:: xml(code)
-    :class: html
-
-..  role:: yaml(code)
-
-..  default-role:: code
-
-..  ---------
-..  highlight
-..  ---------
-
-..  By default, code blocks use PHP syntax highlighting
-
-..  highlight:: php
+..  You can put central messages to display on all pages here

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -6,7 +6,7 @@
 >
     <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
                project-home="https://extensions.typo3.org/extension/mysqlreport"
-               project-contact="mailto:froemken\@gmail.com"
+               project-contact="mailto:froemken@gmail.com"
                project-repository="https://github.com/froemken/mysqlreport"
                project-issues="https://github.com/froemken/mysqlreport/issues"
                edit-on-github-branch="main"


### PR DESCRIPTION
This commit brings the documentation up to speed with the latest TYPO3 rendering toolchain conventions. `Includes.rst.txt` has been cleaned up from legacy Sphinx text roles and default highlighting. Standard inline code formatting replaces the previous custom roles in `ChangeLog/Index.rst`. Finally, it fixes an invalid `mailto:` format inside the `guides.xml` configuration file.

---
*PR created automatically by Jules for task [14853038415922165342](https://jules.google.com/task/14853038415922165342) started by @froemken*